### PR TITLE
Allow setting a custom signal

### DIFF
--- a/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.Designer.cs
+++ b/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.Designer.cs
@@ -54,6 +54,8 @@
             this.cmbTaPresetsTime = new System.Windows.Forms.ComboBox();
             this.label6 = new System.Windows.Forms.Label();
             this.radioButtonTaPresets = new System.Windows.Forms.RadioButton();
+            this.radioButtonCustom = new System.Windows.Forms.RadioButton();
+            this.txtCustom = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.numRsiPoints)).BeginInit();
             this.panelRsi.SuspendLayout();
             this.panelTradingView.SuspendLayout();
@@ -342,11 +344,32 @@
             this.radioButtonTaPresets.UseVisualStyleBackColor = true;
             this.radioButtonTaPresets.CheckedChanged += new System.EventHandler(this.radioButton_CheckedChanged);
             // 
+            // radioButtonCustom
+            // 
+            this.radioButtonCustom.AutoSize = true;
+            this.radioButtonCustom.Location = new System.Drawing.Point(13, 151);
+            this.radioButtonCustom.Name = "radioButtonCustom";
+            this.radioButtonCustom.Size = new System.Drawing.Size(60, 17);
+            this.radioButtonCustom.TabIndex = 36;
+            this.radioButtonCustom.Text = "Custom";
+            this.radioButtonCustom.UseVisualStyleBackColor = true;
+            this.radioButtonCustom.CheckedChanged += new System.EventHandler(this.radioButton_CheckedChanged);
+            // 
+            // txtCustom
+            // 
+            this.txtCustom.Location = new System.Drawing.Point(118, 151);
+            this.txtCustom.Name = "txtCustom";
+            this.txtCustom.Size = new System.Drawing.Size(147, 20);
+            this.txtCustom.TabIndex = 37;
+            this.txtCustom.Visible = false;
+            // 
             // ChooseSignal
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(457, 221);
+            this.Controls.Add(this.txtCustom);
+            this.Controls.Add(this.radioButtonCustom);
             this.Controls.Add(this.panelTaPresets);
             this.Controls.Add(this.radioButtonTaPresets);
             this.Controls.Add(this.panelUlt);
@@ -408,5 +431,7 @@
         private System.Windows.Forms.ComboBox cmbTaPresetsTime;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.RadioButton radioButtonTaPresets;
+        private System.Windows.Forms.RadioButton radioButtonCustom;
+        private System.Windows.Forms.TextBox txtCustom;
     }
 }

--- a/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.cs
+++ b/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.cs
@@ -96,7 +96,16 @@ namespace _3Commas.BulkEditor.Views.ChooseSignal
 
             if (radioButtonManual.Checked) _strategy = new ManualStrategy();
             if (radioButtonNonstop.Checked) _strategy = new NonStopBotStrategy();
-            if (radioButtonCustom.Checked) _strategy = new UnknownStrategy(txtCustom.Text);
+            
+            if (radioButtonCustom.Checked)
+            {
+                if (string.IsNullOrWhiteSpace(txtCustom.Text))
+                {
+                    MessageBox.Show("Name is missing");
+                    return;
+                }
+                _strategy = new UnknownStrategy(txtCustom.Text);
+            }
 
             this.DialogResult = DialogResult.OK;
         }

--- a/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.cs
+++ b/src/3Commas.BulkEditor/Views/ChooseSignal/ChooseSignal.cs
@@ -29,6 +29,7 @@ namespace _3Commas.BulkEditor.Views.ChooseSignal
             panelUlt.Visible = (sender == radioButtonUlt);
             panelTaPresets.Visible = (sender == radioButtonTaPresets);
             panelTradingView.Visible = (sender == radioButtonTradingView);
+            txtCustom.Visible = (sender == radioButtonCustom);
         }
 
         private void okButton_Click(object sender, EventArgs e)
@@ -95,6 +96,7 @@ namespace _3Commas.BulkEditor.Views.ChooseSignal
 
             if (radioButtonManual.Checked) _strategy = new ManualStrategy();
             if (radioButtonNonstop.Checked) _strategy = new NonStopBotStrategy();
+            if (radioButtonCustom.Checked) _strategy = new UnknownStrategy(txtCustom.Text);
 
             this.DialogResult = DialogResult.OK;
         }


### PR DESCRIPTION
Allows setting a custom signal to start bot (useful for marketplace signals).

![image](https://user-images.githubusercontent.com/383616/93916694-3772eb80-fd0a-11ea-8b01-72f9ad76a40b.png)
